### PR TITLE
Remove full method deprecation

### DIFF
--- a/src/Registry.php
+++ b/src/Registry.php
@@ -451,13 +451,11 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
      *
      * @param  string  $path       Registry Path (e.g. joomla.content.showauthor)
      * @param  mixed   $value      Value of entry
-     * @param  string  $separator  The key separator
+     * @param  string  $separator  The key separator. Will be removed in version 4.
      *
      * @return  mixed  The value of the that has been set.
      *
      * @since   1.0.0
-     *
-     * @deprecated The $separator parameter will be removed in version 4.
      */
     public function set($path, $value, $separator = null)
     {


### PR DESCRIPTION
### Summary of Changes

`@deprecated` phpDoc on `Registry::set()` causes false-positive IDE inspection results in Joomla, this tag can't be used to mark a deprecated param but only a deprecated method.

### Testing Instructions
No.
### Documentation Changes Required
No.